### PR TITLE
fix bug#45 propertyNames

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,7 @@ CHANGES
 examples/add1.pl
 examples/forum14944-3.pl
 examples/forum15100-round-numbers.pl
+examples/forum19486-list-lexer-propertyNames.pl
 examples/genRandomText.pl
 examples/npp_selection_filenames_md5.pl
 examples/readme.txt
@@ -42,6 +43,7 @@ t/npp-menucmd.t
 t/npp-meta.t
 t/npp-sci.t
 t/sci-auto.t
+t/sci-hlprfns.t
 t/sci-manu.t
 t/sci-testcases.t
 t/sci-undo.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -150,7 +150,7 @@ LICENSE :: lib/Win32/Mechanize/NotepadPlusPlus.pm Makefile.PL
 	pod2text LICENSE.pod LICENSE
 	$(RM_F) LICENSE.pod
 
-docs :: README.md LICENSE populateversion
+docs :: README.md LICENSE manifest populateversion
 
 # auto-generate the messages-modules for Notepad++ GUI and Scintilla Editor -- this is run by developer, not during the install suite
 

--- a/examples/list_all_UDL.pl
+++ b/examples/list_all_UDL.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Win32::Mechanize::NotepadPlusPlus qw/:all/;
+

--- a/examples/list_all_UDL.pl
+++ b/examples/list_all_UDL.pl
@@ -1,7 +1,0 @@
-#!/usr/bin/env perl
-
-use strict;
-use warnings;
-
-use Win32::Mechanize::NotepadPlusPlus qw/:all/;
-

--- a/lib/Win32/Mechanize/NotepadPlusPlus.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus.pm
@@ -5,7 +5,7 @@ use strict;
 use Exporter 'import';
 use Carp;
 
-our $VERSION = '0.003001';  # rrr.mmmsss : rrr is major revision; mmm is minor revision; sss is sub-revision; optionally use _sss instead, for alpha sub-releases
+our $VERSION = '0.003002';  # rrr.mmmsss : rrr is major revision; mmm is minor revision; sss is sub-revision (new feature path or bugfix); optionally use _sss instead, for alpha sub-releases
 
 use Win32::Mechanize::NotepadPlusPlus::Notepad ':vars';
 use Win32::Mechanize::NotepadPlusPlus::Editor ':vars';

--- a/lib/Win32/Mechanize/NotepadPlusPlus/Editor.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus/Editor.pm
@@ -11465,6 +11465,11 @@ sub AUTOLOAD {
 
 }
 
+my $TRACE_AUTOGEN;
+sub __trace_autogen { $TRACE_AUTOGEN = 1; }
+sub __untrace_autogen { $TRACE_AUTOGEN = 0; }
+# use editor->__trace_raw_string(); to enable debugging for the auto-generated methods
+
 sub __auto_generate($) {
     my %info = %{ $_[0] };
     my ($method, $sci) = @info{qw/subName sciName/};
@@ -11487,6 +11492,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs}//[] } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->SendMessage($SCIMSG{$sci}, 0, 0);
         };
     } elsif( $info{subRet}//'<undef>' eq 'str' and $nSciArgs==2 and $info{sciArgs}[1] =~ /^\Qchar *\E/ and $info{sciArgs}[0] =~ /\Qchar *\E/) {
@@ -11504,6 +11510,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet},
 #;
 #printf STDERR qq|\tcalled as %s("%s")\n|, $method, join(', ', $wparam_string//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             my $args = { trim => 'retval' };
 
             return $self->{_hwobj}->SendMessage_sendRawString_getRawString( $SCIMSG{$sci} , $wparam_string, $args );
@@ -11521,6 +11528,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet},
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $wparam//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             my $args = { trim => 'retval'};
             if( !defined $wparam ) {
                 # when not defined, need to pass a 0 and tell it to derive the SendMessage wParam from the length rather than from the passed wParam
@@ -11544,6 +11552,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $wstring//'<undef>', $lstring//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->{_hwobj}->SendMessage_sendTwoRawStrings( $SCIMSG{$sci}, $wstring, $lstring );
         };
     } elsif( 2==$nSubArgs and $info{sciArgs}[1] =~ /^\Qconst char *\E/) {
@@ -11560,6 +11569,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $wparam//'<undef>', $lstring//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->{_hwobj}->SendMessage_sendRawString( $SCIMSG{$sci}, $wparam, $lstring );
         };
     } elsif( 1==$nSubArgs and 1==$nSciArgs and $info{sciArgs}[0] =~ /^\Qconst char *\E/) {
@@ -11576,6 +11586,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $wstring//'<undef>', $lparam//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->{_hwobj}->SendMessage_sendRawStringAsWparam( $SCIMSG{$sci}, $wstring, $lparam );
         };
     } elsif( 1==$nSubArgs and 2==$nSciArgs and $info{sciArgs}[0] =~ /length$/ and $info{sciArgs}[1] =~ /^\Qconst char *\E/) {
@@ -11592,6 +11603,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $lstring//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->{_hwobj}->SendMessage_sendRawString( $SCIMSG{$sci}, $wparam, $lstring );
         };
     } elsif( 1==$nSubArgs and 2==$nSciArgs and $info{sciArgs}[1] =~ /^\Qconst char *\E/) {
@@ -11607,6 +11619,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $lstring//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->{_hwobj}->SendMessage_sendRawString( $SCIMSG{$sci}, 0, $lstring );
         };
     } elsif( 1==$nSubArgs and 2==$nSciArgs and $info{sciArgs}[0] =~ /^\Q<unused>\E/) {
@@ -11622,6 +11635,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $lparam//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->SendMessage( $SCIMSG{$sci}, 0, $lparam );
         };
     } elsif( 2==$nSubArgs and 2==$nSciArgs ) {
@@ -11638,6 +11652,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $wparam//'<undef>', $lparam//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->SendMessage( $SCIMSG{$sci}, $wparam, $lparam);
         };
     } elsif( 1==$nSubArgs and 1==$nSciArgs ) {
@@ -11653,6 +11668,7 @@ sub __auto_generate($) {
 #    $sci, join(', ', @{ $info{sciArgs} } ), $info{sciRet}//'<undef>',
 #;
 #printf STDERR qq|\tcalled as %s(%s)\n|, $method, join(', ', $wparam//'<undef>', @_ );
+            printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
             return $self->SendMessage( $SCIMSG{$sci}, $wparam, 0);
         };
     } else {
@@ -11662,6 +11678,7 @@ sub __auto_generate($) {
         return sub {
                 # uncoverable subroutine
                 # uncoverable statement dummy placeholder should never be reached; I don't even know how to test
+                printf STDERR qq|__%04d__:autogen(%s)\n|, __LINE__, $method if $TRACE_AUTOGEN;
                 sprintf qq|I was created as "%s" with "%s"\n\t(%s)|,
                     $method, $sci,
                     join("\n\t",

--- a/lib/Win32/Mechanize/NotepadPlusPlus/Editor.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus/Editor.pm
@@ -10,7 +10,7 @@ use Win32::Mechanize::NotepadPlusPlus::Editor::Messages;  # exports %SCIMSG, whi
 use utf8;   # there are UTF8 arrows throughout the source code (in POD and strings)
 use Config;
 
-our $VERSION = '0.003001'; # auto-populated from W::M::NPP
+our $VERSION = '0.003002'; # auto-populated from W::M::NPP
 
 our @EXPORT_VARS = (@Win32::Mechanize::NotepadPlusPlus::Editor::Messages::EXPORT);
 our @EXPORT_OK = (@EXPORT_VARS);
@@ -10488,10 +10488,22 @@ See Scintilla documentation for  L<SCI_PROPERTYNAMES|https://www.scintilla.org/S
 
 =cut
 
-$autogen{SCI_PROPERTYNAMES} = {
-    subProto => 'propertyNames() => str',
-    sciProto => 'SCI_PROPERTYNAMES(<unused>, char *names) => int',
-};
+#$autogen{SCI_PROPERTYNAMES} = {
+#    subProto => 'propertyNames() => str',
+#    sciProto => 'SCI_PROPERTYNAMES(<unused>, char *names) => int',
+#};
+
+sub propertyNames {
+    my $self = shift;
+    my $wparam = shift;
+
+    my $args = {
+        trim => 'retval',   # uses return value to determine length
+        wlength => 0,       # retval does _not_ include \0 string terminator
+    };
+    return $self->{_hwobj}->SendMessage_getRawString( $SCIMSG{SCI_PROPERTYNAMES} , 0 , $args );
+}
+
 
 =item propertyType
 

--- a/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
@@ -31,7 +31,7 @@ BEGIN {
     Win32::API::->Import("psapi","BOOL EnumProcessModules(HANDLE  hProcess, HMODULE *lphModule, DWORD   cb, LPDWORD lpcbNeeded)") or die "EnumProcessModules: $^E";  # uncoverable branch true
 }
 
-our $VERSION = '0.003001'; # auto-populated from W::M::NPP
+our $VERSION = '0.003002'; # auto-populated from W::M::NPP
 
 our @EXPORT_VARS = (@Win32::Mechanize::NotepadPlusPlus::Notepad::Messages::EXPORT);
 our @EXPORT_OK = (@EXPORT_VARS);

--- a/t/sci-testcases.t
+++ b/t/sci-testcases.t
@@ -34,15 +34,15 @@ BEGIN {
 
     # original #14: getLine(1) for empty line should NOT return \0
     my $txt = editor->getLine(1);
-    isnt $txt, "\0", 'ISSUE#14: getLine() for empty line should NOT return \0'
+    isnt $txt, "\0", 'ISSUE 14: getLine() for empty line should NOT return \0'
         or diag sprintf "\t!!!!! getLine = \"%s\" !!!!!\n", dumper($txt);
-    is $txt, "", 'ISSUE#14: getLine() for empty line SHOULD return empty string';
+    is $txt, "", 'ISSUE 14: getLine() for empty line SHOULD return empty string';
 
     # reopen #14: ditto for getSelText()
     $txt = editor->getSelText();
-    isnt $txt, "\0", 'ISSUE#14: getSelText() for empty selection should NOT return \0'
+    isnt $txt, "\0", 'ISSUE 14: getSelText() for empty selection should NOT return \0'
         or diag sprintf "\t!!!!! getLine = \"%s\" !!!!!\n", dumper($txt);
-    is $txt, "", 'ISSUE#14: getSelText() for empty selection SHOULD return empty string';
+    is $txt, "", 'ISSUE 14: getSelText() for empty selection SHOULD return empty string';
 
     TODO: {
         # debug: can I tell the difference between the empty string of getSelText and actually finding a NUL character in the selection?
@@ -50,7 +50,7 @@ BEGIN {
         editor->addText("\0");
         editor->selectAll();
         $txt = editor->getSelText();
-        is $txt, "\0", 'getSelText() for actual NUL \\0 SHOULD return \\0 string' or
+        is $txt, "\0", 'ISSUE 14: getSelText() for actual NUL \\0 SHOULD return \\0 string' or
             diag sprintf "\t!!!!! getLine = \"%s\" intentional \\0 !!!!!\n", dumper($txt);
         editor->undo();
     }
@@ -72,13 +72,13 @@ BEGIN {
     # add data
     editor->setText("Hello World");
     my $got = editor->getText();
-    is $got, "Hello World", 'setText("Hello World") should set text';
+    is $got, "Hello World", 'ISSUE 15: setText("Hello World") should set text';
 
     # set blank
     $got = undef;
     eval { editor->setText(""); 1; } or do { $got = "<crash: $@>"; };
     $got //= editor->getText();
-    is $got, "", 'setText("") should clear text';
+    is $got, "", 'ISSUE 15: setText("") should clear text';
 
     # cleanup
     editor->endUndoAction();
@@ -105,13 +105,13 @@ BEGIN {
     editor->setSearchFlags($SC_FIND{SCFIND_REGEXP});
     my $find = editor->searchInTarget('([aeiou])');
         #diag sprintf "searchInTarget('([aeiou])')=%s\n", $searchret//'<undef>';
-    is $find, 1, "searchInTarget('([aeiou])') found the correct first position";
+    is $find, 1, "ISSUE 41-42: searchInTarget('([aeiou])') found the correct first position";
 
     # do the replacement
     editor->replaceTargetRE('_\\1_');
     my $got = editor->getTargetText(); # "H_e_llo World"
         #diag sprintf "getTargetText() after replaceTargetRE = '%s'\n", dumper($got//'<undef>');
-    is $got, 'H_e_llo World', "replaceTargetRE(): use an actual regular expression";
+    is $got, 'H_e_llo World', "ISSUE 41-42: replaceTargetRE(): use an actual regular expression";
 
     # cleanup
     editor->setSavePoint();
@@ -120,6 +120,8 @@ BEGIN {
 
 # propertyNames(): should _not_ have final character chomped
 #   https://github.com/pryrt/Win32-Mechanize-NotepadPlusPlus/issues/45
+#   results of experimenting: as far as I can tell (searching API description for NUL),
+#       propertyNames was the last remaining scintilla message that uses retval but doesn't include NUL in that length
 {
     # prep
     notepad->newFile();
@@ -130,13 +132,13 @@ BEGIN {
     is $t, $LANGTYPE{L_PERL}, 'setLangType(L_PERL) worked';
 
     # this is a dangerous test, because the lexer might change in the future
-editor->__trace_autogen();
-editor->{_hwobj}->__trace_raw_string();
+#editor->__trace_autogen();
+#editor->{_hwobj}->__trace_raw_string();
     my $exp = "fold\nfold.comment\nfold.compact\nfold.perl.pod\nfold.perl.package\nfold.perl.comment.explicit\nfold.perl.at.else";
     my $got = editor->propertyNames();
-    is $got, $exp, 'editor->propertyNames() needs to not chomp the last character';
-editor->{_hwobj}->__untrace_raw_string();
-editor->__untrace_autogen();
+    is $got, $exp, 'ISSUE 45: editor->propertyNames() needs to not chomp the last character';
+#editor->{_hwobj}->__untrace_raw_string();
+#editor->__untrace_autogen();
 
     # cleanup
     editor->setSavePoint();

--- a/t/sci-testcases.t
+++ b/t/sci-testcases.t
@@ -118,5 +118,29 @@ BEGIN {
     notepad->closeAll();
 }
 
+# propertyNames(): should _not_ have final character chomped
+#   https://github.com/pryrt/Win32-Mechanize-NotepadPlusPlus/issues/45
+{
+    # prep
+    notepad->newFile();
+    notepad->setLangType($LANGTYPE{L_PERL});
+    my $t = notepad->getLangType();
+
+    # verify correct language
+    is $t, $LANGTYPE{L_PERL}, 'setLangType(L_PERL) worked';
+
+    # this is a dangerous test, because the lexer might change in the future
+editor->__trace_autogen();
+editor->{_hwobj}->__trace_raw_string();
+    my $exp = "fold\nfold.comment\nfold.compact\nfold.perl.pod\nfold.perl.package\nfold.perl.comment.explicit\nfold.perl.at.else";
+    my $got = editor->propertyNames();
+    is $got, $exp, 'editor->propertyNames() needs to not chomp the last character';
+editor->{_hwobj}->__untrace_raw_string();
+editor->__untrace_autogen();
+
+    # cleanup
+    editor->setSavePoint();
+    notepad->closeAll();
+}
 
 done_testing;


### PR DESCRIPTION
closes #45 => manual wrapper for editor->propertyNames() to stop stripping final (non-NUL) character