### PR TITLE
fix getDebugInfo ; fix SaveAll

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -76,7 +76,7 @@ use 5.010;
             'warnings' => 0,
             'strict' => 0,
             'Test::More' => 0.86,
-			'Test::Exception' => 0,
+            'Test::Exception' => 0,
             'constant' => 0,
             'Config' => 0,
             'Win32' => 0,
@@ -88,7 +88,7 @@ use 5.010;
             'warnings' => 0,
             'strict' => 0,
             'Test::More' => 0.86,
-			'Test::Exception' => 0,
+            'Test::Exception' => 0,
             'constant' => 0,
             'Config' => 0,
             'Path::Tiny' => 0.058,          # 0.018 needed for rootdir and cwd; 0.058 needed for sibling

--- a/_proverc
+++ b/_proverc
@@ -1,0 +1,1 @@
+--verbose 

--- a/_proverc
+++ b/_proverc
@@ -1,1 +1,0 @@
---verbose 

--- a/helpbuild/myMakeHelper.pm
+++ b/helpbuild/myMakeHelper.pm
@@ -95,14 +95,14 @@ sub download_zip {
 
     my %url = (
         64 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
-            name  => 'npp.8.1.4.portable.x64.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.x64.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.x64.zip',
+            name  => 'npp.8.0.portable.x64.zip',
         },
         32 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
-            name  => 'npp.8.1.4.portable.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.zip',
+            name  => 'npp.8.0.portable.zip',
         },
     );
 

--- a/helpbuild/myMakeHelper.pm
+++ b/helpbuild/myMakeHelper.pm
@@ -95,14 +95,14 @@ sub download_zip {
 
     my %url = (
         64 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.x64.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.x64.zip',
-            name  => 'npp.8.0.portable.x64.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
+            name  => 'npp.8.1.4.portable.x64.zip',
         },
         32 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.zip',
-            name  => 'npp.8.0.portable.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
+            name  => 'npp.8.1.4.portable.zip',
         },
     );
 

--- a/helpbuild/myMakeHelper.pm
+++ b/helpbuild/myMakeHelper.pm
@@ -95,14 +95,14 @@ sub download_zip {
 
     my %url = (
         64 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
-            name  => 'npp.8.1.4.portable.x64.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.x64.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.x64.zip',
+            name  => 'npp.8.0.portable.x64.zip',
         },
         32 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
-            name  => 'npp.8.1.4.portable.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.zip',
+            name  => 'npp.8.0.portable.zip',
         },
     );
 

--- a/helpbuild/myMakeHelper.pm
+++ b/helpbuild/myMakeHelper.pm
@@ -95,14 +95,14 @@ sub download_zip {
 
     my %url = (
         64 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9.3/npp.7.9.3.portable.x64.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9.3/npp.7.9.3.portable.x64.zip',
-            name  => 'npp.7.9.3.portable.x64.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.x64.zip',
+            name  => 'npp.8.1.4.portable.x64.zip',
         },
         32 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9.3/npp.7.9.3.portable.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9.3/npp.7.9.3.portable.zip',
-            name  => 'npp.7.9.3.portable.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.4/npp.8.1.4.portable.zip',
+            name  => 'npp.8.1.4.portable.zip',
         },
     );
 

--- a/helpbuild/myMakeHelper.pm
+++ b/helpbuild/myMakeHelper.pm
@@ -95,13 +95,13 @@ sub download_zip {
 
     my %url = (
         64 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.x64.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.x64.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.x64.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.x64.zip',
             name  => 'npp.8.0.portable.x64.zip',
         },
         32 => {
-            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.zip',
-            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.0/npp.8.0.portable.zip',
+            https => 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.zip',
+            http  => 'http://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8/npp.8.0.portable.zip',
             name  => 'npp.8.0.portable.zip',
         },
     );

--- a/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
@@ -2062,7 +2062,7 @@ sub _initDebugInfo {
     }
     # done with dialog
     SetForegroundWindow($hWnd);
-    SendKeys('{ESC}');
+    SendKeys('{PAUSE 250}{ESC}', 250);
 
     for ( split /\R/, $debugInfo ) {
         $DebugInfo{-APP} = $_, next unless exists $DebugInfo{-APP};

--- a/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
@@ -1922,16 +1922,14 @@ sub getPerlBits {
 
     notepad->getCommandLine();
 
-Gets the command line used to start Notepad++
-
-NOT IMPLEMENTED.  RETURNS C<undef>.  (May be implemented in the future.)
+Gets the command line used to start Notepad++, when using v8.0 or newer.
+On older versions, returns C<undef>.
 
 =cut
 
 sub getCommandLine {
     my $self = shift;
-    # https://github.com/bruderstein/PythonScript/blob/1d9230ffcb2c110918c1c9d36176bcce0a6572b6/PythonScript/src/NotepadPlusWrapper.cpp#L893
-    return undef;
+	return $self->getDebugInfo('Command line');
 }
 
 =item getNppDir

--- a/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
+++ b/lib/Win32/Mechanize/NotepadPlusPlus/Notepad.pm
@@ -2062,7 +2062,7 @@ sub _initDebugInfo {
     }
     # done with dialog
     SetForegroundWindow($hWnd);
-    SendKeys('{ENTER}');
+    SendKeys('{ESC}');
 
     for ( split /\R/, $debugInfo ) {
         $DebugInfo{-APP} = $_, next unless exists $DebugInfo{-APP};

--- a/t/npp-files.t
+++ b/t/npp-files.t
@@ -181,6 +181,14 @@ our $knownSession = tempfile( TEMPLATE => 'nppKnownSession_XXXXXXXX', SUFFIX => 
 
     # now save them
     my $ret = notepad->saveAllFiles();
+    for(1) {
+        # TODO: rework to use test helper, because I need to have the forking involved...
+        use Win32::GuiTest ();
+        my $confirm = Win32::GuiTest::WaitWindow(qr/^Save All Confirmation/, 2.0); # wait up to 2sec for SaveAllConfirmation
+        diag "confirm: ", explain($confirm);
+        last unless $confirm;
+        Win32::GuiTest::PushChildButton($confirm, 'Yes', 2.5);
+    }
     ok $ret, sprintf 'saveAllFiles(): ret = %d', $ret;
 
     # should be more-recently modified

--- a/t/npp-meta.t
+++ b/t/npp-meta.t
@@ -49,13 +49,6 @@ $ret = notepad()->getPerlBits;
 ok $ret, 'getPerlBits';
     note sprintf "\t=> \"%s\"", defined $ret ? explain $ret : '<undef>';
 
-TODO: {
-    local $TODO = 'unimplemented';
-    $ret = notepad()->getCommandLine;
-    is $ret, '', 'getCommandLine';
-    note sprintf "\t=> \"%s\"", defined $ret ? explain $ret : '<undef>';
-}
-
 $ret = notepad()->getNppDir;
 ok $ret, 'getNppDir';
     note sprintf "\t=> \"%s\"", defined $ret ? explain $ret : '<undef>';
@@ -129,5 +122,14 @@ my ($p, $a) = notepad->getDebugInfo('path', 'Admin Mode');
 like $p, qr/\Qnotepad++.exe\E/i, 'getDebugInfo(path, Admin Mode) => path contains executable';
 like $a, qr/(ON|OFF)/i, 'getDebugInfo(path, Admin Mode) => mode is on or off';
     note sprintf "\tpath => %s\n\tAdmin mode => %s\n", $p, $a;
+
+SKIP: {
+    #skip "getDebugInfo('Command Line') because using $ver < required v8.0", 1 if $ver < version->parse(v8.0.0);
+    $ret = notepad()->getCommandLine;
+	my $exp = undef;
+    is $ret, $exp, 'getCommandLine';
+    note sprintf "\t=> \"%s\"", defined $ret ? explain $ret : '<undef>';
+}
+
 
 done_testing;

--- a/t/npp-meta.t
+++ b/t/npp-meta.t
@@ -123,13 +123,13 @@ like $p, qr/\Qnotepad++.exe\E/i, 'getDebugInfo(path, Admin Mode) => path contain
 like $a, qr/(ON|OFF)/i, 'getDebugInfo(path, Admin Mode) => mode is on or off';
     note sprintf "\tpath => %s\n\tAdmin mode => %s\n", $p, $a;
 
-SKIP: {
-    #skip "getDebugInfo('Command Line') because using $ver < required v8.0", 1 if $ver < version->parse(v8.0.0);
-    $ret = notepad()->getCommandLine;
-	my $exp = undef;
-    is $ret, $exp, 'getCommandLine';
-    note sprintf "\t=> \"%s\"", defined $ret ? explain $ret : '<undef>';
+$ret = notepad()->getCommandLine;
+if($ver < version->parse(v8.0.0)) {
+	is $ret, undef, "getCommandLine expects undef for $ver";
+} else {
+	isnt $ret, undef, "getCommandLine expects defined for $ver";
 }
+note sprintf "\t=> \"%s\"", defined $ret ? explain $ret : '<undef>';
 
 
 done_testing;


### PR DESCRIPTION
make sure getDebugInfo properly closes window without causing edits to the existing file (especially for testing).

make sure editor->saveAllFiles() test coverage will work with v8.1.2 and later (with confirmation dialogs)

all this needed to be fixed before I could move on to my goal of getStatusBar implementation.  want to merge this back into master before implementing new feature